### PR TITLE
feat: add tooltips to reservation and report pages

### DIFF
--- a/resources/views/report.blade.php
+++ b/resources/views/report.blade.php
@@ -42,8 +42,29 @@
         @endif
         @if ($tickets->count() > 0)
 
+            <div id="refresh-tooltip" role="tooltip"
+                class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700">
+                Refresca la tabla de reservas
+                <div class="tooltip-arrow" data-popper-arrow></div>
+            </div>
+            <div id="initDate-tooltip" role="tooltip"
+                class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700">
+                Fecha de inicio
+                <div class="tooltip-arrow" data-popper-arrow></div>
+            </div>
+            <div id="finishDate-tooltip" role="tooltip"
+                class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700">
+                Fecha de término
+                <div class="tooltip-arrow" data-popper-arrow></div>
+            </div>
+            <div id="search-tooltip" role="tooltip"
+                class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700">
+                Buscar reservas en el rango de fechas
+                <div class="tooltip-arrow" data-popper-arrow></div>
+            </div>
+
             <div class="flex justify-center gap-4">
-                <a href="{{ route('report.index') }}"
+                <a data-tooltip-target="refresh-tooltip" data-tooltip-placement="left" href="{{ route('report.index') }}"
                     class="bg-yellow-300 transition-all my-auto py-3 px-3 text-white rounded-lg">
                     <svg class="w-4 h-4 hover:animate-spin text-gray-800 dark:text-white" aria-hidden="true"
                         xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 20">
@@ -62,7 +83,7 @@
                                         d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4ZM0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z" />
                                 </svg>
                             </div>
-                            <input onkeydown="return false" datepicker type="date" name="initDate"
+                            <input data-tooltip-target="initDate-tooltip" data-tooltip-placement="top" onkeydown="return false" datepicker type="date" name="initDate"
                                 value="{{ old('initDate') }}"
                                 class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
                                 placeholder="Select date">
@@ -76,13 +97,13 @@
                                         d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4ZM0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z" />
                                 </svg>
                             </div>
-                            <input onkeydown="return false" datepicker type="date" name="endDate"
+                            <input data-tooltip-target="finishDate-tooltip" data-tooltip-placement="top" onkeydown="return false" datepicker type="date" name="endDate"
                                 value="{{ old('finishDate') }}"
                                 class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
                                 placeholder="Select date">
                         </div>
 
-                        <button type="submit"
+                        <button data-tooltip-target="search-tooltip" data-tooltip-placement="right" type="submit"
                             class="bg-blue-custom-50 hover:bg-blue-custom-100 transition-all py-2 px-4 text-white rounded-lg">
                             Buscar
                         </button>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -93,11 +93,16 @@
                         });
                     </script>
                 @endpush
+                <div id="reservation-tooltip" role="tooltip"
+                    class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700">
+                    Recuerda llenar todos los campos
+                    <div class="tooltip-arrow" data-popper-arrow></div>
+                </div>
                 <div class="grid gap-4 mb-4">
                     <div class="flex items-center justify-center rounded  h-4 mt-2 md:h-6 lg:h-8">
                         <button type="button" id="reservationButton" style="white-space: nowrap;"
                             class="px-1 py-3 text-base font-medium text-center text-white opacity-25 bg-blue-custom-50 rounded-lg  focus:ring-4 focus:ring-blue-300 sm:w-auto dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
-                            <a href="#">Reservar Pasajes</a>
+                            <a data-tooltip-target="reservation-tooltip" data-tooltip-placement="right" href="#">Reservar Pasajes</a>
                         </button>
 
                     </div>


### PR DESCRIPTION
Se añaden tooltips a las página de reserva de pasajes y reporte de pasajes. Los tooltips presentes en la página de reporte de pasajes corresponden a los siguientes:

- Refrescar tabla: Se añade un tooltip al botón que refresca la tabla con el mensaje "Refresca la tabla de reservas".
- Fecha de inicio: Se añade un tooltip al objeto que representa la fecha de inicio de la reserva con el mensaje "Fecha de inicio".
- Fecha de término: Se añade un tooltip al objeto que representa la fecha de término de la reserva con el mensaje "Fecha de término".
- Buscar: Se añade un tooltip al botón que realiza la búsqueda de reservas con el mensaje "Buscar reservas en el rango de fechas".

Para la página de reserva de pasajes sólo se añade un tooltip correspondiente con el botón para realizar las reservas con el mensaje "Recuerda llenar todos los campos".